### PR TITLE
API fixes

### DIFF
--- a/create.go
+++ b/create.go
@@ -45,7 +45,9 @@ func (rt *Runtime) Create(ctx context.Context, cfg *ContainerConfig) (*Container
 		return c, errorf("failed to run container process: %w", err)
 	}
 
-	return c, nil
+	p := c.RuntimePath("container.json")
+	err := encodeFileJSON(p, c, os.O_EXCL|os.O_CREATE|os.O_RDWR, 0640)
+	return c, err
 }
 
 // CheckSystem checks the hosts system configuration.

--- a/create.go
+++ b/create.go
@@ -3,15 +3,11 @@ package lxcri
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
-	"github.com/creack/pty"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/sys/unix"
 	"gopkg.in/lxc/go-lxc.v2"
 )
 
@@ -323,46 +319,4 @@ func writeMasked(dst string, c *Container) error {
 		}
 	}
 	return f.Close()
-}
-
-func runStartCmdConsole(ctx context.Context, cmd *exec.Cmd, consoleSocket string) error {
-	dialer := net.Dialer{}
-	c, err := dialer.DialContext(ctx, "unix", consoleSocket)
-	if err != nil {
-		return fmt.Errorf("connecting to console socket failed: %w", err)
-	}
-	defer c.Close()
-
-	conn, ok := c.(*net.UnixConn)
-	if !ok {
-		return fmt.Errorf("expected a unix connection but was %T", conn)
-	}
-
-	if deadline, ok := ctx.Deadline(); ok {
-		err = conn.SetDeadline(deadline)
-		if err != nil {
-			return fmt.Errorf("failed to set connection deadline: %w", err)
-		}
-	}
-
-	sockFile, err := conn.File()
-	if err != nil {
-		return fmt.Errorf("failed to get file from unix connection: %w", err)
-	}
-	ptmx, err := pty.Start(cmd)
-	if err != nil {
-		return fmt.Errorf("failed to start with pty: %w", err)
-	}
-
-	// Send the pty file descriptor over the console socket (to the 'conmon' process)
-	// For technical backgrounds see:
-	// * `man sendmsg 2`, `man unix 3`, `man cmsg 1`
-	// * https://blog.cloudflare.com/know-your-scm_rights/
-	oob := unix.UnixRights(int(ptmx.Fd()))
-	// Don't know whether 'terminal' is the right data to send, but conmon doesn't care anyway.
-	err = unix.Sendmsg(int(sockFile.Fd()), []byte("terminal"), oob, nil, 0)
-	if err != nil {
-		return fmt.Errorf("failed to send console fd: %w", err)
-	}
-	return ptmx.Close()
 }

--- a/create.go
+++ b/create.go
@@ -16,9 +16,6 @@ import (
 // You may have to call Runtime.Delete to cleanup container runtime state,
 // if Create returns with an error.
 func (rt *Runtime) Create(ctx context.Context, cfg *ContainerConfig) (*Container, error) {
-	ctx, cancel := context.WithTimeout(ctx, rt.Timeouts.Create)
-	defer cancel()
-
 	if err := rt.checkConfig(cfg); err != nil {
 		return nil, err
 	}

--- a/runtime.go
+++ b/runtime.go
@@ -167,7 +167,7 @@ func (rt *Runtime) Start(ctx context.Context, c *Container) error {
 
 func (rt *Runtime) runStartCmd(ctx context.Context, c *Container) (err error) {
 	// #nosec
-	cmd := exec.Command(rt.libexec(ExecStart), c.linuxcontainer.Name(), rt.Root, c.ConfigFilePath())
+	cmd := exec.Command(rt.libexec(ExecStart), c.LinuxContainer.Name(), rt.Root, c.ConfigFilePath())
 	cmd.Env = []string{}
 	cmd.Dir = c.RuntimePath()
 

--- a/runtime.go
+++ b/runtime.go
@@ -55,7 +55,7 @@ type Hooks struct {
 
 type Runtime struct {
 	// Log is the logger used by the runtime.
-	Log zerolog.Logger
+	Log zerolog.Logger `json:"-"`
 	// Root is the file path to the runtime directory.
 	// Directories for containers created by the runtime
 	// are created within this directory.

--- a/utils.go
+++ b/utils.go
@@ -12,31 +12,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// createPidFile atomically creates a pid file for the given pid at the given path
-func CreatePidFile(path string, pid int) error {
-	tmpDir := filepath.Dir(path)
-	tmpName := filepath.Join(tmpDir, fmt.Sprintf(".%s", filepath.Base(path)))
-
-	// #nosec
-	f, err := os.OpenFile(tmpName, os.O_RDWR|os.O_CREATE|os.O_EXCL|os.O_SYNC, 0600)
-	if err != nil {
-		return fmt.Errorf("failed to create temporary PID file %q: %w", tmpName, err)
-	}
-	_, err = fmt.Fprintf(f, "%d", pid)
-	if err != nil {
-		return fmt.Errorf("failed to write to temporary PID file %q: %w", tmpName, err)
-	}
-	err = f.Close()
-	if err != nil {
-		return fmt.Errorf("failed to close temporary PID file %q: %w", tmpName, err)
-	}
-	err = os.Rename(tmpName, path)
-	if err != nil {
-		return fmt.Errorf("failed to rename temporary PID file %q to %q: %w", tmpName, path, err)
-	}
-	return nil
-}
-
 func canExecute(cmds ...string) error {
 	for _, c := range cmds {
 		if err := unix.Access(c, unix.X_OK); err != nil {


### PR DESCRIPTION
* Expose lxc.Container again.
* Serialize Container with lxcri-start PID.
* Removed default timeouts from API 